### PR TITLE
chore: 🤖 Forgot to specify this scoped package is public

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "require": "./dist/sqhooks.cjs.js"
     }
   },
+  "private": false,
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
@@ -64,6 +65,9 @@
     "semantic-release": "^17.4.2",
     "typescript": "^4.1.2",
     "vite": "^2.1.3"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "commitlint": {
     "rules": {


### PR DESCRIPTION
By default, scoped packages (@selectquotelabs/) are private, need to
specify public access in package.json