### PR TITLE
feat: 🎸 add useClipboard hook with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,45 @@ const {storedValue, setValue} = useLocalStorage('ID', 'abc123');
 }
 ```
 
+---
+
+### useClipboard
+
+**Description** Returns a function to copy a given value to the clipboard, and a ref to pass to an element to enable copying its `innerText` using the function as the element's `onClick` handler.
+
+**Example**
+
+```javascript
+// copies 'hello'
+const {onClick, ref} = useClipboard();
+return (
+  <button onClick={onClick} ref={ref}>
+    hello
+  </button>
+);
+
+// copies 'world'
+const {onClick, ref} = useClipboard('world');
+return (
+  <button onClick={onClick} ref={ref}>
+    hello
+  </button>
+);
+```
+
+**Parameters**
+
+`contentToCopy: string` (optional) Content to copy to the clipboard when `onClick` is called. If a value is not specified, the `innerText` of the clicked element will be copied.
+
+**Returns**
+
+```typescript
+{
+  onClick: () => Promise<void>;
+  ref: React.RefObject<HTMLElement>;
+}
+```
+
 ## Migrate to SQHooks
 
 Use the library for net-new code. As a PR reviewer, encourage the use of Hooks from this library. Squads should create backlog tickets to replace a hook, with it's SQHooks equivalent.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,7 @@ import {useDialog} from './useDialog';
 import {usePrevious} from './usePrevious';
 import {useDebounce, useDebouncedCallback} from 'use-debounce';
 import {useLocalStorage} from './useLocalStorage';
+import {useClipboard} from './useClipboard';
 
 export {
   useDialog,
@@ -9,4 +10,5 @@ export {
   useDebounce,
   useDebouncedCallback,
   useLocalStorage,
+  useClipboard,
 };

--- a/src/hooks/useClipboard.test.ts
+++ b/src/hooks/useClipboard.test.ts
@@ -1,0 +1,23 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+import {useClipboard} from '.';
+
+Object.defineProperty(navigator, 'clipboard', {
+  value: {
+    writeText: jest.fn(),
+  },
+});
+
+describe('useClipboard', () => {
+  jest.spyOn(navigator.clipboard, 'writeText');
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should copy a given value to clipboard', async () => {
+    const {result} = renderHook(() => useClipboard('hello world'));
+    await act(() => result.current.onClick());
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('hello world');
+  });
+});

--- a/src/hooks/useClipboard.ts
+++ b/src/hooks/useClipboard.ts
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function useClipboard(contentToCopy?: string) {
+  const clickTargetRef = React.useRef<HTMLElement>(null);
+
+  const writeContentToClipboard = async () => {
+    await navigator.clipboard.writeText(
+      contentToCopy || clickTargetRef.current?.innerText || ''
+    );
+  };
+
+  return {onClick: writeContentToClipboard, ref: clickTargetRef};
+}


### PR DESCRIPTION
Copied from sc2-senior

## Checklist

- [x] Tests for the changes have been added (for bug fixes / features) and all tests are passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No `useClipboard` hook

Ref: #8 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `useClipboard` hook

## Screenshots/Loom

https://www.loom.com/share/4558ab9cf1f645388a6b6a6e6bbeedef

## Other information

I was able to test copying text to the clipboard via passing in a value to `contentToCopy`, however I wasn't able to come up with a way to test copying text by clicking an element (other than manually testing it in that Loom). I believe that may be out of the scope of hooks testing
