### PR TITLE
feat: 🎸 add useIsomorphicLocalStorage hook with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,38 @@ const {storedValue, setValue} = useLocalStorage('ID', 'abc123');
 }
 ```
 
+---
+
+### useIsomorphicLocalStorage
+
+**Description** An isomorphic version of `useLocalStorage`. Sync state to local storage (similar to `useState`) so that it persists through a page refresh. Tests utilize the [`jest-localstorage-mock`](https://www.npmjs.com/package/jest-localstorage-mock).
+
+**Example**
+
+```javascript
+const {storedValue, storeValue, isFetching} = useIsomorphicLocalStorage(
+  'ID',
+  'abc123'
+);
+```
+
+**Parameters**
+
+`key: string` The localStorage key you want to read/create/update.
+
+`initialValue` (optional) The initial value to set if the value of the key in localStorage is empty.
+
+**Returns**
+the stored value from localStorage, a function to store a value in localStorage, and a boolean value to indicate fetching state.
+
+```typescript
+{
+  storedValue: string;
+  storeValue: React.Dispatch<React.SetStateAction<Type | undefined>>;
+  isFetching: boolean;
+}
+```
+
 ## Migrate to SQHooks
 
 Use the library for net-new code. As a PR reviewer, encourage the use of Hooks from this library. Squads should create backlog tickets to replace a hook, with it's SQHooks equivalent.

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,6 +2,7 @@ import {useDialog} from './useDialog';
 import {usePrevious} from './usePrevious';
 import {useDebounce, useDebouncedCallback} from 'use-debounce';
 import {useLocalStorage} from './useLocalStorage';
+import {useIsomorphicLocalStorage} from './useIsomorphicLocalStorage';
 
 export {
   useDialog,
@@ -9,4 +10,5 @@ export {
   useDebounce,
   useDebouncedCallback,
   useLocalStorage,
+  useIsomorphicLocalStorage,
 };

--- a/src/hooks/useIsomorphicLocalStorage.test.ts
+++ b/src/hooks/useIsomorphicLocalStorage.test.ts
@@ -1,0 +1,110 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+import 'jest-localstorage-mock';
+import {useIsomorphicLocalStorage} from '.';
+
+describe('useIsomorphicLocalStorage', () => {
+  afterEach(() => {
+    localStorage.clear();
+    jest.clearAllMocks();
+  });
+
+  it('should retrieve an existing item from localStorage', () => {
+    const expectedResult = 'abc123';
+    localStorage.setItem('ID', `"${expectedResult}"`);
+    const {result} = renderHook(() => useIsomorphicLocalStorage('ID'));
+    const {storedValue, isFetching} = result.current;
+
+    expect(storedValue).toEqual(expectedResult);
+    expect(isFetching).toBe(false);
+  });
+
+  it('should return initialValue if the provided localStorage key is empty and set that item to localStorage', () => {
+    const expectedResult = 'abc123';
+    const {result} = renderHook(() =>
+      useIsomorphicLocalStorage('ID', expectedResult)
+    );
+    const {storedValue, isFetching} = result.current;
+
+    expect(storedValue).toEqual(expectedResult);
+    expect(localStorage.__STORE__.ID).toEqual(`"${expectedResult}"`);
+    expect(isFetching).toBe(false);
+  });
+
+  it('should use existing value over initial state', () => {
+    const expectedResult = 'abc123';
+    localStorage.setItem('ID', `"${expectedResult}"`);
+    const {result} = renderHook(() =>
+      useIsomorphicLocalStorage('ID', 'def456')
+    );
+    const {storedValue, isFetching} = result.current;
+
+    expect(storedValue).toEqual(expectedResult);
+    expect(isFetching).toBe(false);
+  });
+
+  it('should not overwrite existing localStorage value with initialState', () => {
+    const expectedResult = 'abc123';
+    localStorage.setItem('ID', `"${expectedResult}"`);
+    renderHook(() => useIsomorphicLocalStorage('ID', 'def456'));
+
+    expect(localStorage.__STORE__.ID).toEqual(`"${expectedResult}"`);
+  });
+
+  it('immediately returns a newly set value', () => {
+    const {result} = renderHook(() => {
+      return useIsomorphicLocalStorage('ID', 'abc123');
+    });
+    const {storeValue} = result.current;
+
+    act(() => storeValue('def456'));
+
+    const {storedValue} = result.current;
+    expect(storedValue).toEqual('def456');
+  });
+
+  it('properly updates localStorage value', () => {
+    const {result} = renderHook(() =>
+      useIsomorphicLocalStorage('ID', 'abc123')
+    );
+    const {storeValue} = result.current;
+
+    act(() => storeValue('def456'));
+
+    expect(localStorage.__STORE__.ID).toEqual('"def456"');
+  });
+
+  it('should return empty string if no initialValue is provided and the localStorage value is empty', () => {
+    const {result} = renderHook(() => useIsomorphicLocalStorage('ID'));
+    const {storedValue} = result.current;
+
+    expect(storedValue).toEqual('');
+  });
+
+  it('sets localStorage value using function updater', () => {
+    const {result} = renderHook(() => {
+      return useIsomorphicLocalStorage<string>('user', 'firstName');
+    });
+
+    const {storeValue} = result.current;
+    act(() => storeValue((state) => state && state + 'lastName'));
+
+    const {storedValue} = result.current;
+    expect(storedValue).toEqual('firstNamelastName');
+  });
+
+  it('throws on null or undefined keys', () => {
+    const {result} = renderHook(() => useIsomorphicLocalStorage(null as any));
+    let errorResult: string;
+
+    try {
+      (() => {
+        return result.current;
+      })();
+      throw Error();
+    } catch (error) {
+      errorResult = String(error);
+    }
+
+    expect(errorResult).toMatch(/key must not be falsy/);
+  });
+});

--- a/src/hooks/useIsomorphicLocalStorage.ts
+++ b/src/hooks/useIsomorphicLocalStorage.ts
@@ -1,0 +1,73 @@
+import React from 'react';
+
+/**
+ * This hook supports two types of use cases --
+ * 1. const [storedValue, storeValue] = useIsomorphicLocalStorage(key, weKnowThisValueUpFrontAndWantToInitializeItInLocalStorage)
+ * 2. const [storedValue, storeValue] = useIsomorphicLocalStorage(key) <-- no up front value known (need to create it on backend, etc)
+ * @param {string} key
+ * @param {string | number | function | object | array | undefined} initialValue
+ * @returns [any, function]
+ */
+export function useIsomorphicLocalStorage<Type>(
+  key: string,
+  initialValue?: Type
+): {
+  storedValue: string;
+  storeValue: React.Dispatch<React.SetStateAction<Type | undefined>>;
+  isFetching: boolean;
+} {
+  if (!key) {
+    throw new Error('useIsomorphicLocalStorage key must not be falsy');
+  }
+
+  const [storedValue, setStoredValue] = React.useState('hello');
+  const [isFetching, setIsFetching] = React.useState(true);
+  const storedStringValue =
+    typeof window !== 'undefined' ? window.localStorage.getItem(key) : null;
+
+  const storeValue: React.Dispatch<
+    React.SetStateAction<Type | undefined>
+  > = React.useCallback(
+    (value) => {
+      // Allow value to be a function so we have same API as useState
+      // see usehooks.com/useLocalStorage
+      const valueToStore =
+        value instanceof Function ? (value as Function)(storedValue) : value;
+
+      // save new user token into local storage
+      // fall back to empty string if `value` is nullish
+      window.localStorage.setItem(key, JSON.stringify(valueToStore ?? ''));
+
+      setStoredValue(valueToStore ?? '');
+    },
+    [key, storedValue]
+  );
+
+  React.useEffect(() => {
+    // if this is running on the server, bail out... no localStorage there!
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    // if localStorage is null for that key, initialize it in localStorage and in local state here as the initialValue
+    if (storedStringValue === null) {
+      storeValue(initialValue);
+      setIsFetching(false);
+      return;
+    }
+
+    const parsedValue = JSON.parse(storedStringValue);
+
+    // if localStorage value matches initialValue, we've either invoked the hook with the default initialValue OR we've already stored the initialValue
+    if (parsedValue === initialValue) {
+      setIsFetching(false);
+      return;
+    }
+
+    // if there's a value in localStorage, sync local state with it
+    setStoredValue(parsedValue);
+    setIsFetching(false);
+  }, [initialValue, storeValue, storedStringValue]);
+
+  return {storedValue, storeValue, isFetching};
+}

--- a/src/hooks/useIsomorphicLocalStorage.ts
+++ b/src/hooks/useIsomorphicLocalStorage.ts
@@ -2,8 +2,8 @@ import React from 'react';
 
 /**
  * This hook supports two types of use cases --
- * 1. const [storedValue, storeValue] = useIsomorphicLocalStorage(key, weKnowThisValueUpFrontAndWantToInitializeItInLocalStorage)
- * 2. const [storedValue, storeValue] = useIsomorphicLocalStorage(key) <-- no up front value known (need to create it on backend, etc)
+ * 1. const {storedValue, storeValue} = useIsomorphicLocalStorage(key, weKnowThisValueUpFrontAndWantToInitializeItInLocalStorage)
+ * 2. const {storedValue, storeValue} = useIsomorphicLocalStorage(key) <-- no up front value known (need to create it on backend, etc)
  * @param {string} key
  * @param {string | number | function | object | array | undefined} initialValue
  * @returns [any, function]


### PR DESCRIPTION
Copied the hook from senior-external-qe-ui and updated for typescript.
Repurposed most of the tests from `useLocalStorage` since it basically
works the same as that hook - except that it doesn't allow
setting/returning null values or objects in localStorage.

## Checklist

- [x] Tests for the changes have been added (for bug fixes / features) and all tests are passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

No `useIsomorphicLocalStorage` hook
Ref: #8 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- `useIsomorphicLocalStorage` hook

## Screenshots/Loom

## Other information


