### PR TITLE
feat: 🎸 useDropdownOption returns empty array with empty data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Local Development
 
+NPM Version: [lts/fermium](https://nodejs.org/en/about/releases/)
+
 ```bash
 > npm install
 ```
@@ -335,3 +337,11 @@ return (
 ## Migrate to SQHooks
 
 Use the library for net-new code. As a PR reviewer, encourage the use of Hooks from this library. Squads should create backlog tickets to replace a hook, with it's SQHooks equivalent.
+
+## Upgrading
+
+### v1 to v2
+
+Affected hooks: `useDropdownOptions`
+
+v2 of SQHooks includes a change to `useDropdownOptions` that allows it to return an empty array. Previously if an empty array was passed for `items` then the hook would return an array with the "empty" option, `{label: '- -', value: null}`. v2 will now return an empty array. If you still want that "empty" on your dropdown or autocomplete then you should use the `displayEmpty` prop on your component.

--- a/src/hooks/useDropdownOptions.test.ts
+++ b/src/hooks/useDropdownOptions.test.ts
@@ -32,16 +32,11 @@ it('should return an array of objects with the correct values', () => {
   expect(value).toEqual(mockData[0].ID);
 });
 
-it('should return an array of one object with default values if no items provided', () => {
+it('should return an empty array if no items provided', () => {
   const {result} = setupRenderHook('hello', 'test');
 
   expect(result.current).toBeInstanceOf(Array);
-  expect(result.current).toHaveLength(1);
-  expect(result.current[0]).toBeInstanceOf(Object);
-
-  const {label, value} = result.current[0];
-  expect(label).toEqual('- -');
-  expect(value).toBeNull();
+  expect(result.current).toHaveLength(0);
 });
 
 it('should return object array based on provided items', () => {

--- a/src/hooks/useDropdownOptions.ts
+++ b/src/hooks/useDropdownOptions.ts
@@ -23,11 +23,7 @@ export function useDropdownOptions(
       );
     }
 
-    if (!items?.length) {
-      return [{label: '- -', value: null}];
-    }
-
-    return items.map((item) => ({label: item[label], value: item[value]}));
+    return items?.map((item) => ({label: item[label], value: item[value]})) || [];
   }, [items, label, value]);
 }
 


### PR DESCRIPTION
useDropdownOptions returns an empty array when an empty array is passed
for the items param instead of the "empty" option

BREAKING CHANGE: 🧨 useDropdownOptions can now return an empty array with the items param is
an empty array

✅ Closes: #27

## Checklist

- [x] Tests for the changes have been added (for bug fixes / features) and all tests are passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## What is the current behavior?
`useDropdownOptions` returns an  array with the "empty" dropdown option if the `items` array is empty
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue: #27

## What is the new behavior?
`useDropdownOptions` returns an _empty_ array if the `items` array is empty.
<!-- Please describe the behavior or changes that are being added by this PR. -->

## Other information
Added the npm version we're using to the README. Caused me issues when I first pulled this project down. Also added an `Upgrading` section to the README about the breaking changes for the new version.