### PR TITLE
fix: 🐛 fix narrow typing of items param in useDropdownOptions

### DIFF
--- a/src/hooks/useDropdownOptions.test.ts
+++ b/src/hooks/useDropdownOptions.test.ts
@@ -1,6 +1,11 @@
 import {renderHook} from '@testing-library/react-hooks';
 import {useDropdownOptions} from '.';
-import {Item} from './useDropdownOptions';
+
+type MockItem = {
+  firstName: string;
+  lastName: string;
+  ID: number;
+};
 
 const mockData = [
   {firstName: 'Franken', lastName: 'Berry', ID: 123},
@@ -10,14 +15,18 @@ const mockData = [
   {firstName: 'Yummy', lastName: 'Mummy', ID: 246},
 ];
 
-const setupRenderHook = (label: string, value: string, items?: Item[]) => {
-  return renderHook(() => useDropdownOptions(label, value, items), {
+const setupRenderHook = <TMockItem>(
+  label: keyof TMockItem,
+  value: keyof TMockItem,
+  items?: TMockItem[]
+) => {
+  return renderHook(() => useDropdownOptions<TMockItem>(label, value, items), {
     initialProps: {items: null},
   });
 };
 
 it('should return an array of objects with the correct properties', () => {
-  const {result} = setupRenderHook('firstName', 'ID', [mockData[0]]);
+  const {result} = setupRenderHook<MockItem>('firstName', 'ID', [mockData[0]]);
 
   expect(Object.keys(result.current[0])).toHaveLength(2);
   expect(result.current[0]).toHaveProperty('label');
@@ -25,7 +34,7 @@ it('should return an array of objects with the correct properties', () => {
 });
 
 it('should return an array of objects with the correct values', () => {
-  const {result} = setupRenderHook('firstName', 'ID', [mockData[0]]);
+  const {result} = setupRenderHook<MockItem>('firstName', 'ID', [mockData[0]]);
   const {label, value} = result.current[0];
 
   expect(label).toEqual(mockData[0].firstName);
@@ -40,7 +49,7 @@ it('should return an empty array if no items provided', () => {
 });
 
 it('should return object array based on provided items', () => {
-  const {result} = setupRenderHook('firstName', 'ID', mockData);
+  const {result} = setupRenderHook<MockItem>('firstName', 'ID', mockData);
 
   expect(result.current).toMatchInlineSnapshot(`
     Array [

--- a/src/hooks/useDropdownOptions.ts
+++ b/src/hooks/useDropdownOptions.ts
@@ -1,9 +1,5 @@
 import React from 'react';
 
-export interface Item {
-  [key: string]: string | number;
-}
-
 /**
  * Transforms your array of objects into the shape our form system expects.
  * Our form system expects an Array of Objects with a shape of [{label: String, value: String}]
@@ -11,10 +7,10 @@ export interface Item {
  * @param {string} value
  * @param {array} items [{item}]
  */
-export function useDropdownOptions(
-  label: string,
-  value: string,
-  items?: Item[]
+export function useDropdownOptions<TItem = {[key: string]: unknown}>(
+  label: keyof TItem,
+  value: keyof TItem,
+  items?: TItem[]
 ) {
   return React.useMemo(() => {
     if (items && !isObjectArray(items)) {


### PR DESCRIPTION
change to generic type TItem so label and value can both be type keyof
TItem

✅ Closes: 31

## Checklist

- [x] Tests for the changes have been added (for bug fixes / features) and all tests are passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue: #31 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- adjusting the type definitions, so consumers can use the generic type TItem, which is the type definition of the object of which parameter `items` is an array.
- following the new generic type, `label` and `value` are now defined as `keyof TItem`, which is a bit more flexible
-

## Screenshots/Loom

## Other information
