### PR TITLE
fix: 🐛 correct useAutoHeight logic and return type

### DIFF
--- a/src/hooks/useAutoHeight.test.ts
+++ b/src/hooks/useAutoHeight.test.ts
@@ -18,7 +18,7 @@ describe('useAutoHeight', () => {
     const autoHeightDiv = document.createElement('div');
 
     act(() => {
-      result.current.containerRef(autoHeightDiv as HTMLElement);
+      result.current.containerRef(autoHeightDiv as HTMLDivElement);
     });
 
     expect(mockSetState).toHaveBeenCalledWith(autoHeightDiv);
@@ -60,7 +60,7 @@ describe('useAutoHeight', () => {
     );
 
     act(() => {
-      result.current.containerRef(autoHeightDiv as HTMLElement);
+      result.current.containerRef(autoHeightDiv as HTMLDivElement);
     });
 
     expect(result.current.autoHeight).toEqual(

--- a/src/hooks/useAutoHeight.ts
+++ b/src/hooks/useAutoHeight.ts
@@ -1,10 +1,14 @@
 import React from 'react';
 
-export function useAutoHeight() {
+interface useAutoHeightReturn {
+  autoHeight: string | undefined;
+  containerRef: (node: HTMLDivElement) => void;
+}
+export function useAutoHeight(): useAutoHeightReturn {
   const [containerRef, setContainerRef] = React.useState<
-    HTMLElement | undefined
+    HTMLDivElement | undefined
   >();
-  const refCallback = (node: HTMLElement) => {
+  const refCallback = (node: HTMLDivElement) => {
     setContainerRef(node);
   };
 
@@ -17,7 +21,9 @@ export function useAutoHeight() {
     const offsetBasedHeight = `calc(100vh - ${topOffset}px - 24px)`;
 
     const parentHeight = containerRef.parentElement?.clientHeight;
-    const parentPadding = containerRef.parentElement?.style.paddingBottom;
+    const parentPadding = containerRef?.parentElement?.style.paddingBottom
+      ? containerRef?.parentElement?.style.paddingBottom
+      : '0px';
     const parentTopOffset =
       containerRef.parentElement?.getBoundingClientRect().top ?? 0;
     const topDifferential = topOffset - parentTopOffset;

--- a/src/hooks/useAutoHeight.ts
+++ b/src/hooks/useAutoHeight.ts
@@ -21,9 +21,8 @@ export function useAutoHeight(): useAutoHeightReturn {
     const offsetBasedHeight = `calc(100vh - ${topOffset}px - 24px)`;
 
     const parentHeight = containerRef.parentElement?.clientHeight;
-    const parentPadding = containerRef?.parentElement?.style.paddingBottom
-      ? containerRef?.parentElement?.style.paddingBottom
-      : '0px';
+    const parentPadding =
+      containerRef?.parentElement?.style.paddingBottom || '0px';
     const parentTopOffset =
       containerRef.parentElement?.getBoundingClientRect().top ?? 0;
     const topDifferential = topOffset - parentTopOffset;


### PR DESCRIPTION
add a return type for the useAutoheight hook as well as adjust a small
logic change that corrects an issue where we are returning a broken
height amount.

✅ Closes: #37

## Checklist

- [x] Tests for the changes have been added (for bug fixes / features) and all tests are passing
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
It seems if the useAutoHeight cannot find a style value for "paddingBottom" on the parent container, it will break the calculation being used to determine the overall calculated Height. 

Issue: #37 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- This introduces a simple ternary that returns '0px' is there is no value found for the parent's style prop. 

## Screenshots/Loom https://www.loom.com/share/0ca6bc569a4245beb02451b88263fe93

## Other information
